### PR TITLE
Migrate from Commons Lang to native Java Platform functionality

### DIFF
--- a/src/main/java/com/netsparker/cloud/plugin/NCScanBuilder.java
+++ b/src/main/java/com/netsparker/cloud/plugin/NCScanBuilder.java
@@ -28,7 +28,6 @@ import com.netsparker.cloud.model.WebsiteModelRequest;
 import com.netsparker.cloud.model.WebsiteProfileModel;
 import com.netsparker.cloud.utility.AppCommon;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.jenkinsci.Symbol;
 import org.json.simple.parser.ParseException;
@@ -57,6 +56,7 @@ import hudson.util.ListBoxModel.Option;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
+import hudson.Util;
 
 public class NCScanBuilder extends Builder implements SimpleBuildStep {
 
@@ -320,10 +320,10 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
 
                 DescriptorImpl descriptor = getDescriptor();
                 
-                String ncServerURL = StringUtils.isBlank(getNcServerURL()) ? descriptor.getNcServerURL()
+                String ncServerURL = Util.fixEmptyAndTrim(getNcServerURL()) == null ? descriptor.getNcServerURL()
                     : getNcServerURL();
 
-                if (!StringUtils.isEmpty(credentialsId)) {
+                if (Util.fixEmpty(credentialsId) != null) {
                     // build.getEnvironment().get("job_name")
                     // "Folder 1/Folder 1 - Folder 1/Folder 1 - Folder 1 - Folder 1/Child Project"
                     final StandardUsernamePasswordCredentials credential = AppCommon.findCredentialsById(
@@ -339,7 +339,7 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
                 // from settings
                 if (ncApiToken == null || ncApiToken.getPlainText().isEmpty()) {
                     ncApiToken =
-                            getNcApiToken() != null && StringUtils.isBlank(getNcApiToken().getPlainText())
+                            getNcApiToken() != null && Util.fixEmptyAndTrim(getNcApiToken().getPlainText()) == null
                                     ? descriptor.getNcApiToken()
                                     : getNcApiToken();
                 }
@@ -357,16 +357,16 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
                         : getUseProxy();
 
                 if (useProxy != null && useProxy) {
-                    pHost = StringUtils.isBlank(getpHost()) ? descriptor.getpHost()
+                    pHost = Util.fixEmptyAndTrim(getpHost()) == null ? descriptor.getpHost()
                         : getpHost();
                 
-                    pPort = StringUtils.isBlank(getpPort()) ? descriptor.getpPort()
+                    pPort = Util.fixEmptyAndTrim(getpPort()) == null ? descriptor.getpPort()
                             : getpPort();
                 
-                    pUser = StringUtils.isBlank(getpUser()) ? descriptor.getpUser()
+                    pUser = Util.fixEmptyAndTrim(getpUser()) == null ? descriptor.getpUser()
                             : getpUser();
                 
-                    pPassword = StringUtils.isBlank(getpPassword()) ? descriptor.getpPassword()
+                    pPassword = Util.fixEmptyAndTrim(getpPassword()) == null ? descriptor.getpPassword()
                         : getpPassword();
 
                     proxy = new ProxyBlock(useProxy, pHost, pPort, pUser, pPassword);
@@ -431,7 +431,7 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
             throws Exception {
 
         DescriptorImpl descriptor = getDescriptor();
-        String ncServerURL = StringUtils.isBlank(getNcServerURL()) ? descriptor.getNcServerURL()
+        String ncServerURL = Util.fixEmptyAndTrim(getNcServerURL()) == null ? descriptor.getNcServerURL()
                 : getNcServerURL();
 
         Secret ncApiToken = null;
@@ -446,16 +446,16 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
                 : getUseProxy();
         
         if (useProxy != null && useProxy) {
-            pHost = StringUtils.isBlank(getpHost()) ? descriptor.getpHost()
+            pHost = Util.fixEmptyAndTrim(getpHost()) == null ? descriptor.getpHost()
                 : getpHost();
         
-            pPort = StringUtils.isBlank(getpPort()) ? descriptor.getpPort()
+            pPort = Util.fixEmptyAndTrim(getpPort()) == null ? descriptor.getpPort()
                     : getpPort();
 
-            pUser = StringUtils.isBlank(getpUser()) ? descriptor.getpUser()
+            pUser = Util.fixEmptyAndTrim(getpUser()) == null ? descriptor.getpUser()
                     : getpUser();
 
-            pPassword = StringUtils.isBlank(getpPassword()) ? descriptor.getpPassword()
+            pPassword = Util.fixEmptyAndTrim(getpPassword()) == null ? descriptor.getpPassword()
                 : getpPassword();
             
             proxy = new ProxyBlock(useProxy, pHost, pPort, pUser, pPassword);
@@ -464,7 +464,7 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
         // jenkin's server url
         String rootUrl = null;
 
-        if (!StringUtils.isEmpty(credentialsId)) {
+        if (Util.fixEmpty(credentialsId) != null) {
 
             // build.getEnvironment().get("job_name")
             // "Folder 1/Folder 1 - Folder 1/Folder 1 - Folder 1 - Folder 1/Child Project"
@@ -481,7 +481,7 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
         // from settings
         if (ncApiToken == null || ncApiToken.getPlainText().isEmpty()) {
             ncApiToken =
-                    getNcApiToken() != null && StringUtils.isBlank(getNcApiToken().getPlainText())
+                    getNcApiToken() != null && Util.fixEmptyAndTrim(getNcApiToken().getPlainText()) == null
                             ? descriptor.getNcApiToken()
                             : getNcApiToken();
         }
@@ -491,7 +491,7 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
         }
 
         // StringUtils.isEmpty checks null or empty
-        if (StringUtils.isEmpty(rootUrl)) {
+        if (Util.fixEmpty(rootUrl) == null) {
             rootUrl = descriptor.getRootURL();
         }
 
@@ -837,7 +837,7 @@ public class NCScanBuilder extends Builder implements SimpleBuildStep {
         public ListBoxModel doFillNcWebsiteIdItems(@QueryParameter String credentialsId) {
       
 
-            if (!StringUtils.isEmpty(credentialsId)) {
+            if (Util.fixEmpty(credentialsId) != null) {
                 doTestConnection(credentialsId);
             }
 


### PR DESCRIPTION
No need to use a third-party library when this functionality is available in the Java Platform.

Part of the effort to remove Commons Lang 2 from Jenkins core — jenkinsci/jenkins#16404,
jenkinsci/jenkins#26105. Commons Lang 2 is EOL and carries an unfixed advisory
(GHSA-j288-q9x7-2f5v).

`StringUtils.isBlank` / `isEmpty` become the `hudson.Util.fixEmpty*` helpers.

### Testing done

`mvn -B -ntp clean verify` passes locally on Java 21 / macOS.
The `ban-commons-lang-2` enforcer rule was left disabled because it needs parent POM
`6.2116.v7501b_67dc517` or newer; bumping the parent from `5.26` was out of scope here.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

---

🤖 This pull request was generated with AI assistance (Claude Code) as part of a bulk migration
across Jenkins plugins. If anything here looks wrong, please comment on this PR or contact
@parameter.
